### PR TITLE
docs: upgrade guide, remind people to upgrade third-party configs like tailwind.config.js

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -135,6 +135,20 @@ nuxt.config.ts
 1. Create a new directory called `app/`.
 1. Move your `assets/`, `components/`, `composables/`, `layouts/`, `middleware/`, `pages/`, `plugins/` and `utils/` folders under it, as well as `app.vue`, `error.vue`, `app.config.ts`. If you have an `app/router-options.ts` or `app/spa-loading-template.html`, these paths remain the same.
 1. Make sure your `nuxt.config.ts`, `modules/`, `public/` and `server/` folders remain outside the `app/` folder, in the root of your project.
+1. Remember to update all of your third-party libraries to work with the new directory structure. E.g., if you use *Tailwind CSS*, update your `tailwind.config.js` to include `app/`:
+
+``` ts [tailwind.config.js]
+module.exports = {
+  content: [
+    "./app/components/**/*.{js,vue,ts}",
+    "./app/layouts/**/*.vue",
+    "./app/pages/**/*.vue",
+    "./app/plugins/**/*.{js,ts}",
+    "./app/app.vue",
+    "./app/error.vue",
+  ],
+/// ...
+```
 
 However, migration is _not required_. If you wish to keep your current folder structure, Nuxt should auto-detect it. (If it does not, please raise an issue.) The one exception is that if you _already_ have a custom `srcDir`. In this case, you should be aware that your `modules/`, `public/` and `server/` folders will be resolved from your `rootDir` rather than from your custom `srcDir`. You can override this by configuring `dir.modules`, `dir.public` and `serverDir` if you need to.
 


### PR DESCRIPTION
https://nuxt.com/docs/getting-started/upgrade

In the "_New Directory Structure_" Section, it should be mentioned to upgrade any third-party libraries depending on the directory structure. In many cases, this might be Tailwind CSS.

### 📚 Description

The Upgrade Guide includes a significant change, which is the new Directory Structure.

Since many projects depend on third-party libraries and processors, a reminder to upgrade these configs in your project as well might be beneficial, namely `tailwind.config.js`